### PR TITLE
Add support for Python 3.11

### DIFF
--- a/xxtea.c
+++ b/xxtea.c
@@ -36,6 +36,12 @@
 #define PyString_AS_STRING PyBytes_AsString
 #endif
 
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
+static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
+{ ob->ob_size = size; }
+#define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)
+#endif
+
 #define XFREE(o) do { if ((o) == NULL) ; else free(o); } while (0)
 
 #define DELTA 0x9e3779b9
@@ -337,7 +343,7 @@ static PyObject *xxtea_decrypt(PyObject *self, PyObject *args, PyObject *kwargs)
     if (padding) {
         if (rc >= 0) {
             /* Remove PKCS#7 padded chars */
-            Py_SIZE(retval) = rc;
+            Py_SET_SIZE(retval, rc);
         }
         else {
             /* Illegal PKCS#7 padding */

--- a/xxtea.c
+++ b/xxtea.c
@@ -37,6 +37,9 @@
 #endif
 
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
+#if defined(_MSC_VER) && !defined(inline)
+#define inline __inline /* required for py2.x support on windows */
+#endif
 static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
 { ob->ob_size = size; }
 #define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)


### PR DESCRIPTION
Python 3.11 builds fail because Py_SIZE macro was replaced by a function. Py_SET_SIZE should be used instead for writes, and a macro is provided for backwards compatibility. See https://docs.python.org/3.11/whatsnew/3.11.html