### PR TITLE
Add XXTEA type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 CHANGELOG
 --------------
 
+v5.0.0a1 2026/04/30
+~~~~~~~~~~~~~~~~~~~
+
+- Add :class:`XXTEA` type — reusable cipher object holding key, padding, and rounds.
+  ``encrypt()``, ``decrypt()``, ``encrypt_hex()``, and ``decrypt_hex()`` take only data,
+  using the stored settings.
+- Validate ``rounds`` is non-negative and fits in ``unsigned int`` (raises ``OverflowError``).
+- Use C99 designated initializers for ``PyModuleDef`` and ``PyType_Spec``.
+
 v4.0.0 2026/04/27
 ~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ xxtea |github-actions-badge| |pypi-badge| |supported-pythons-badge| |license-bad
     :alt: CodSpeed
 
 .. _XXTEA: http://en.wikipedia.org/wiki/XXTEA
-.. _longs2bytes: https://github.com/ifduyue/xxtea/blob/master/xxtea.c#L140
-.. _bytes2longs: https://github.com/ifduyue/xxtea/blob/master/xxtea.c#L98
+.. _longs2bytes: https://github.com/ifduyue/xxtea/blob/master/xxtea.c#L136
+.. _bytes2longs: https://github.com/ifduyue/xxtea/blob/master/xxtea.c#L94
 .. _PKCS#7: http://en.wikipedia.org/wiki/Padding_%28cryptography%29#PKCS7
 
 XXTEA_ implemented as a Python extension module, licensed under 2-clause BSD.
@@ -53,7 +53,8 @@ Usage
 -----------
 
 This module provides four functions: ``encrypt()``, ``decrypt()``,
-``encrypt_hex()``, and ``decrypt_hex()``.
+``encrypt_hex()``, and ``decrypt_hex()``, plus an ``XXTEA`` type for
+reusable cipher objects.
 
 .. code-block:: Python
 
@@ -77,6 +78,41 @@ This module provides four functions: ``encrypt()``, ``decrypt()``,
     >>>
     >>> binascii.hexlify(enc) == hexenc
     True
+
+
+XXTEA Type
+-----------
+
+The ``XXTEA`` type holds a 16-byte key, rounds, and padding setting,
+so you can encrypt and decrypt multiple times without passing them each call.
+
+.. code-block:: python
+
+    >>> from xxtea import XXTEA
+    >>>
+    >>> cipher = XXTEA(key, padding=False, rounds=128)
+    >>> cipher
+    <xxtea.XXTEA object at 0x...>
+    >>>
+    >>> enc = cipher.encrypt(b'12345678')
+    >>> cipher.decrypt(enc)
+    b'12345678'
+    >>>
+    >>> hexenc = cipher.encrypt_hex(b'12345678')
+    >>> cipher.decrypt_hex(hexenc)
+    b'12345678'
+
+``rounds`` defaults to ``0`` (auto), ``padding`` defaults to ``True``.
+``rounds=0`` means ``6 + 52 / n``, where n is the number of 32-bit words in the data.
+They are stored on the object and used by every ``encrypt()``, ``decrypt()``,
+``encrypt_hex()``, and ``decrypt_hex()`` call:
+
+.. code-block:: python
+
+    >>> c = XXTEA(key)                          # rounds=0, padding=True
+    >>> c = XXTEA(key, rounds=64)         # override rounds
+    >>> c = XXTEA(key, padding=False)     # disable padding
+    >>> c = XXTEA(key, padding=False, rounds=42)
 
 
 ``encrypt_hex()`` and ``decrypt_hex()`` operate on ciphertext in a hexadecimal
@@ -179,4 +215,8 @@ may be raised:
     >>> try_catch(xxtea.decrypt_hex, 'abcd', key=' '*16)
     ValueError : Invalid data, data length is not a multiple of 4, or less than 8.
     >>> try_catch(xxtea.encrypt, b'x', b'k'*16, rounds=2**32)
+    OverflowError : rounds value too large
+    >>> try_catch(XXTEA, key=b'short')
+    ValueError : Need a 16-byte key.
+    >>> try_catch(XXTEA, key=b'k'*16, rounds=2**32)
     OverflowError : rounds value too large

--- a/tests/test.py
+++ b/tests/test.py
@@ -411,5 +411,184 @@ class TestArgPassing(unittest.TestCase):
             xxtea.decrypt(self.enc, self.key, True, 2**32)
 
 
+class TestXXTEAType(unittest.TestCase):
+    """Tests for the XXTEA type (cipher object)."""
+
+    data = b'How do you do?'
+    key = b'Fine. And you?  '
+    enc = b'x\xf4e\xeb\x1bI\x85\x88}\x11\x84.\xde\x856!'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cipher = xxtea.XXTEA(cls.key)
+
+    # ── basic round-trip ────────────────────────────────────────────────
+
+    def test_encrypt(self):
+        enc = self.cipher.encrypt(self.data)
+        self.assertEqual(enc, self.enc)
+
+    def test_decrypt(self):
+        data = self.cipher.decrypt(self.enc)
+        self.assertEqual(data, self.data)
+
+    def test_roundtrip(self):
+        enc = self.cipher.encrypt(self.data)
+        dec = self.cipher.decrypt(enc)
+        self.assertEqual(dec, self.data)
+
+    # ── random data ─────────────────────────────────────────────────────
+
+    def test_urandom(self):
+        for i in range(2048):
+            key = os.urandom(16)
+            data = os.urandom(i)
+            cipher = xxtea.XXTEA(key)
+
+            enc = cipher.encrypt(data)
+            dec = cipher.decrypt(enc)
+            self.assertEqual(data, dec)
+
+    def test_zero_bytes(self):
+        for i in range(2048):
+            data = b'\0' * i
+
+            key = os.urandom(16)
+            cipher = xxtea.XXTEA(key)
+            enc = cipher.encrypt(data)
+            dec = cipher.decrypt(enc)
+            self.assertEqual(data, dec)
+
+            cipher2 = xxtea.XXTEA(b'\0' * 16)
+            enc = cipher2.encrypt(data)
+            dec = cipher2.decrypt(enc)
+            self.assertEqual(data, dec)
+
+    # ── no-padding ──────────────────────────────────────────────────────
+
+    def test_encrypt_nopadding(self):
+        key = os.urandom(16)
+        cipher = xxtea.XXTEA(key, padding=False)
+        for i in (8, 12, 16, 20):
+            data = os.urandom(i)
+            enc = cipher.encrypt(data)
+            dec = cipher.decrypt(enc)
+            self.assertEqual(data, dec)
+
+    def test_encrypt_nopadding_zero(self):
+        key = os.urandom(16)
+        cipher = xxtea.XXTEA(key, padding=False)
+        for i in (8, 12, 16, 20):
+            data = b'\0' * i
+            enc = cipher.encrypt(data)
+            dec = cipher.decrypt(enc)
+            self.assertEqual(data, dec)
+
+    # ── rounds ──────────────────────────────────────────────────────────
+
+    def test_rounds(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+
+        for r in (0, 1, 8, 32, 64, 128, 256):
+            cipher = xxtea.XXTEA(key, rounds=r)
+            enc = cipher.encrypt(data)
+            dec = cipher.decrypt(enc)
+            self.assertEqual(data, dec)
+
+    def test_different_rounds_produce_different_output(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+        c0 = xxtea.XXTEA(key, rounds=0)
+        c32 = xxtea.XXTEA(key, rounds=32)
+        self.assertNotEqual(c0.encrypt(data), c32.encrypt(data))
+
+    # ── matches module-level functions ──────────────────────────────────
+
+    def test_matches_module_encrypt(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+        cipher = xxtea.XXTEA(key)
+        self.assertEqual(cipher.encrypt(data), xxtea.encrypt(data, key))
+
+    def test_matches_module_decrypt(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+        enc = xxtea.encrypt(data, key)
+        cipher = xxtea.XXTEA(key)
+        self.assertEqual(cipher.decrypt(enc), xxtea.decrypt(enc, key))
+
+    def test_matches_module_with_rounds(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+        cipher = xxtea.XXTEA(key, rounds=42)
+        enc_c = cipher.encrypt(data)
+        enc_m = xxtea.encrypt(data, key, rounds=42)
+        self.assertEqual(enc_c, enc_m)
+        self.assertEqual(cipher.decrypt(enc_m), xxtea.decrypt(enc_c, key, rounds=42))
+
+    def test_matches_module_nopadding(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+        cipher = xxtea.XXTEA(key, padding=False)
+        enc_c = cipher.encrypt(data)
+        enc_m = xxtea.encrypt(data, key, padding=False)
+        self.assertEqual(enc_c, enc_m)
+
+    # ── error cases ─────────────────────────────────────────────────────
+
+    def test_short_key(self):
+        with self.assertRaises(ValueError):
+            xxtea.XXTEA(b'short')
+        with self.assertRaises(ValueError):
+            xxtea.XXTEA(b'this key is way too long!!!')
+
+    def test_rounds_overflow(self):
+        with self.assertRaises(OverflowError):
+            xxtea.XXTEA(self.key, rounds=2**32)
+
+    def test_missing_required_arg(self):
+        with self.assertRaises(TypeError):
+            xxtea.XXTEA()
+
+    def test_invalid_rounds_type(self):
+        with self.assertRaises(TypeError):
+            xxtea.XXTEA(self.key, rounds='not-an-int')
+
+
+    # ── hex methods ─────────────────────────────────────────────────────
+
+    def test_encrypt_hex(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+        cipher = xxtea.XXTEA(key)
+        hexenc = cipher.encrypt_hex(data)
+        dec = cipher.decrypt_hex(hexenc)
+        self.assertEqual(dec, data)
+
+    def test_encrypt_hex_matches(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+        cipher = xxtea.XXTEA(key)
+        self.assertEqual(cipher.encrypt_hex(data),
+                         xxtea.encrypt_hex(data, key))
+
+    def test_decrypt_hex_matches(self):
+        key = os.urandom(16)
+        data = os.urandom(32)
+        hexenc = xxtea.encrypt_hex(data, key)
+        cipher = xxtea.XXTEA(key)
+        self.assertEqual(cipher.decrypt_hex(hexenc),
+                         xxtea.decrypt_hex(hexenc, key))
+
+    # ── padding at construction ──────────────────────────────────────────
+
+    def test_padding_construction(self):
+        key = os.urandom(16)
+        for padding in (True, False):
+            cipher = xxtea.XXTEA(key, padding=padding)
+            self.assertEqual(cipher.decrypt(cipher.encrypt(b'12345678')), b'12345678')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -17,6 +17,11 @@ ENC_HUGE = xxtea.encrypt(DATA_HUGE, KEY)
 HEXENC_MEDIUM = xxtea.encrypt_hex(DATA_MEDIUM, KEY)
 HEXENC_HUGE = xxtea.encrypt_hex(DATA_HUGE, KEY)
 
+CIPHER = xxtea.XXTEA(KEY)
+
+CIPHER_HEXENC_MEDIUM = CIPHER.encrypt_hex(DATA_MEDIUM)
+CIPHER_HEXENC_HUGE = CIPHER.encrypt_hex(DATA_HUGE)
+
 
 def test_encrypt_small(benchmark):
     benchmark(xxtea.encrypt, DATA_SMALL, KEY)
@@ -64,3 +69,53 @@ def test_encrypt_hex_huge(benchmark):
 
 def test_decrypt_hex_huge(benchmark):
     benchmark(xxtea.decrypt_hex, HEXENC_HUGE, KEY)
+
+
+# ── XXTEA type ──────────────────────────────────────────────────────────
+
+def test_type_encrypt_small(benchmark):
+    benchmark(CIPHER.encrypt, DATA_SMALL)
+
+
+def test_type_encrypt_medium(benchmark):
+    benchmark(CIPHER.encrypt, DATA_MEDIUM)
+
+
+def test_type_encrypt_large(benchmark):
+    benchmark(CIPHER.encrypt, DATA_LARGE)
+
+
+def test_type_decrypt_small(benchmark):
+    benchmark(CIPHER.decrypt, ENC_SMALL)
+
+
+def test_type_decrypt_medium(benchmark):
+    benchmark(CIPHER.decrypt, ENC_MEDIUM)
+
+
+def test_type_decrypt_large(benchmark):
+    benchmark(CIPHER.decrypt, ENC_LARGE)
+
+
+def test_type_encrypt_huge(benchmark):
+    benchmark(CIPHER.encrypt, DATA_HUGE)
+
+
+def test_type_decrypt_huge(benchmark):
+    benchmark(CIPHER.decrypt, ENC_HUGE)
+
+
+def test_type_encrypt_hex_medium(benchmark):
+    benchmark(CIPHER.encrypt_hex, DATA_MEDIUM)
+
+
+def test_type_decrypt_hex_medium(benchmark):
+    benchmark(CIPHER.decrypt_hex, CIPHER_HEXENC_MEDIUM)
+
+
+def test_type_encrypt_hex_huge(benchmark):
+    benchmark(CIPHER.encrypt_hex, DATA_HUGE)
+
+
+def test_type_decrypt_hex_huge(benchmark):
+    benchmark(CIPHER.decrypt_hex, CIPHER_HEXENC_HUGE)

--- a/xxtea.c
+++ b/xxtea.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#define VERSION "4.0.0"
+#define VERSION "5.0.0a1"
 
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
 static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
@@ -349,8 +349,7 @@ _encrypt_impl(const char *data_buf, Py_ssize_t data_len,
         return NULL;
     }
 
-    char *retbuf = PyBytes_AsString(retval);
-    longs2bytes(d, alen, retbuf, 0);
+    longs2bytes(d, alen, PyBytes_AsString(retval), 0);
 
     free(d);
     return retval;
@@ -378,8 +377,6 @@ _decrypt_impl(const char *data_buf, Py_ssize_t data_len,
         return NULL;
     }
 
-    char *retbuf = PyBytes_AsString(retval);
-
     /* not divided by 4, or length < 8 */
     if (data_len & 3 || data_len < 8) {
         PyErr_SetString(PyExc_ValueError,
@@ -401,6 +398,7 @@ _decrypt_impl(const char *data_buf, Py_ssize_t data_len,
         return PyErr_NoMemory();
     }
 
+    char *retbuf = PyBytes_AsString(retval);
     Py_ssize_t rc;
     Py_BEGIN_ALLOW_THREADS
     bytes2longs(data_buf, data_len, d, 0);
@@ -478,8 +476,8 @@ xxtea_encrypt_hex(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObj
     if (!tmp)
         return NULL;
 
-    PyObject *retval = PyObject_CallOneArg(
-        ((xxtea_mod_state*)PyModule_GetState(self))->binascii_hexlify, tmp);
+    xxtea_mod_state *state = (xxtea_mod_state*)PyModule_GetState(self);
+    PyObject *retval = PyObject_CallOneArg(state->binascii_hexlify, tmp);
     Py_DECREF(tmp);
     return retval;
 }
@@ -512,7 +510,7 @@ xxtea_decrypt(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject 
 
 PyDoc_STRVAR(
     xxtea_decrypt_hex_doc,
-    "decrypt_hex (data, key, padding=True)\n\n"
+    "decrypt_hex (data, key, padding=True, rounds=0)\n\n"
     "Decrypt hex encoded `data` with a 16-byte `key`, return original bytes.");
 
 static PyObject *
@@ -527,9 +525,8 @@ xxtea_decrypt_hex(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObj
         return NULL;
 
     /* Unhexlify hex string to bytes, then use shared buffer helper */
-    PyObject *tmp = PyObject_CallOneArg(
-        ((xxtea_mod_state*)PyModule_GetState(self))->binascii_unhexlify,
-        data_obj);
+    xxtea_mod_state *state = (xxtea_mod_state*)PyModule_GetState(self);
+    PyObject *tmp = PyObject_CallOneArg(state->binascii_unhexlify, data_obj);
     if (!tmp)
         return NULL;
 
@@ -544,6 +541,173 @@ xxtea_decrypt_hex(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObj
     Py_DECREF(tmp);
     return retval;
 }
+
+/*****************************************************************************
+ * XXTEA Type ****************************************************************
+ ****************************************************************************/
+
+
+
+typedef struct {
+    PyObject_HEAD
+    char key[16];
+    unsigned int rounds;
+    int padding;
+} xxtea_object;
+
+static int
+xxtea_object_init(xxtea_object *self, PyObject *args, PyObject *kwargs)
+{
+    static char *kwlist[] = {"key", "padding", "rounds", NULL};
+    Py_buffer key_buf = {NULL};
+    int padding = 1;
+    Py_ssize_t rounds = 0;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "y*|pn", kwlist,
+                                     &key_buf, &padding, &rounds))
+        return -1;
+
+    if (key_buf.len != 16) {
+        PyErr_SetString(PyExc_ValueError, "Need a 16-byte key.");
+        PyBuffer_Release(&key_buf);
+        return -1;
+    }
+
+    if (rounds < 0 || (size_t)rounds > UINT_MAX) {
+        PyErr_SetString(PyExc_OverflowError, "rounds value too large");
+        PyBuffer_Release(&key_buf);
+        return -1;
+    }
+
+    memcpy(self->key, key_buf.buf, 16);
+    self->rounds = (unsigned int)rounds;
+    self->padding = padding;
+    PyBuffer_Release(&key_buf);
+    return 0;
+}
+
+static void
+xxtea_object_dealloc(xxtea_object *self)
+{
+    PyTypeObject *tp = Py_TYPE(self);
+    tp->tp_free((PyObject *)self);
+    Py_DECREF(tp);
+}
+
+static PyObject *
+xxtea_object_encrypt(xxtea_object *self, PyObject *data_obj)
+{
+    Py_buffer data_buf = {NULL};
+
+    if (PyObject_GetBuffer(data_obj, &data_buf, PyBUF_SIMPLE) < 0)
+        return NULL;
+
+    PyObject *retval = _encrypt_impl(data_buf.buf, data_buf.len,
+                                      self->key, self->padding, self->rounds);
+    PyBuffer_Release(&data_buf);
+    return retval;
+}
+
+static PyObject *
+xxtea_object_decrypt(xxtea_object *self, PyObject *data_obj)
+{
+    Py_buffer data_buf = {NULL};
+
+    if (PyObject_GetBuffer(data_obj, &data_buf, PyBUF_SIMPLE) < 0)
+        return NULL;
+
+    PyObject *retval = _decrypt_impl(data_buf.buf, data_buf.len,
+                                      self->key, self->padding, self->rounds);
+    PyBuffer_Release(&data_buf);
+    return retval;
+}
+
+static PyObject *
+xxtea_object_encrypt_hex(xxtea_object *self, PyObject *data_obj)
+{
+    Py_buffer data_buf = {NULL};
+
+    if (PyObject_GetBuffer(data_obj, &data_buf, PyBUF_SIMPLE) < 0)
+        return NULL;
+
+    PyObject *tmp = _encrypt_impl(data_buf.buf, data_buf.len,
+                                   self->key, self->padding, self->rounds);
+    PyBuffer_Release(&data_buf);
+    if (!tmp)
+        return NULL;
+
+    xxtea_mod_state *state = PyType_GetModuleState(Py_TYPE(self));
+    if (!state || !state->binascii_hexlify) {
+        Py_DECREF(tmp);
+        PyErr_SetString(PyExc_RuntimeError, "module state not available");
+        return NULL;
+    }
+    PyObject *retval = PyObject_CallOneArg(state->binascii_hexlify, tmp);
+    Py_DECREF(tmp);
+    return retval;
+}
+
+static PyObject *
+xxtea_object_decrypt_hex(xxtea_object *self, PyObject *data_obj)
+{
+    xxtea_mod_state *state = PyType_GetModuleState(Py_TYPE(self));
+    if (!state || !state->binascii_unhexlify) {
+        PyErr_SetString(PyExc_RuntimeError, "module state not available");
+        return NULL;
+    }
+    PyObject *tmp = PyObject_CallOneArg(state->binascii_unhexlify, data_obj);
+    if (!tmp)
+        return NULL;
+
+    Py_buffer data_buf = {NULL};
+    if (PyObject_GetBuffer(tmp, &data_buf, PyBUF_SIMPLE) < 0) {
+        Py_DECREF(tmp);
+        return NULL;
+    }
+
+    PyObject *retval = _decrypt_impl(data_buf.buf, data_buf.len,
+                                      self->key, self->padding, self->rounds);
+    PyBuffer_Release(&data_buf);
+    Py_DECREF(tmp);
+    return retval;
+}
+
+static PyMethodDef xxtea_object_methods[] = {
+    {"encrypt", (PyCFunction)xxtea_object_encrypt, METH_O,
+     "encrypt(data)\n\n"
+     "Encrypt data with the stored key, padding, and rounds."},
+    {"decrypt", (PyCFunction)xxtea_object_decrypt, METH_O,
+     "decrypt(data)\n\n"
+     "Decrypt data with the stored key, padding, and rounds."},
+    {"encrypt_hex", (PyCFunction)xxtea_object_encrypt_hex, METH_O,
+     "encrypt_hex(data)\n\n"
+     "Encrypt data and return hex-encoded bytes."},
+    {"decrypt_hex", (PyCFunction)xxtea_object_decrypt_hex, METH_O,
+     "decrypt_hex(data)\n\n"
+     "Decrypt hex-encoded data and return original bytes."},
+    {NULL, NULL, 0, NULL}
+};
+
+
+static PyType_Slot xxtea_type_slots[] = {
+    {Py_tp_dealloc, (void *)xxtea_object_dealloc},
+    {Py_tp_doc, (void *)"XXTEA(key, padding=True, rounds=0)\n\n"
+                "XXTEA cipher object.  rounds=0 means auto: 6 + 52 / n, "
+                "where n is the number of 32-bit words in the data.\n"
+                "Methods: encrypt(data), decrypt(data), "
+                "encrypt_hex(data), decrypt_hex(data)."},
+    {Py_tp_methods, xxtea_object_methods},
+    {Py_tp_init, (void *)xxtea_object_init},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL}
+};
+
+static PyType_Spec xxtea_type_spec = {
+    .name = "xxtea.XXTEA",
+    .basicsize = sizeof(xxtea_object),
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = xxtea_type_slots,
+};
 
 /*****************************************************************************
  * Module Init ****************************************************************
@@ -574,6 +738,16 @@ static int _exec(PyObject *module)
     }
 
     PyModule_AddStringConstant(module, "VERSION", VERSION);
+
+    PyObject *xxtea_type = PyType_FromModuleAndSpec(module, &xxtea_type_spec, NULL);
+    if (xxtea_type == NULL)
+        return -1;
+    if (PyDict_SetItemString(PyModule_GetDict(module), "XXTEA", xxtea_type) < 0) {
+        Py_DECREF(xxtea_type);
+        return -1;
+    }
+    Py_DECREF(xxtea_type);
+
     return 0;
 }
 
@@ -596,20 +770,20 @@ static PyModuleDef_Slot slots[] = {
 
 static int _traverse(PyObject *module, visitproc visit, void *arg)
 {
-    xxtea_mod_state *module_state = (xxtea_mod_state*)PyModule_GetState(module);
-    if (module_state) {
-        Py_VISIT(module_state->binascii_hexlify);
-        Py_VISIT(module_state->binascii_unhexlify);
+    xxtea_mod_state *state = (xxtea_mod_state*)PyModule_GetState(module);
+    if (state) {
+        Py_VISIT(state->binascii_hexlify);
+        Py_VISIT(state->binascii_unhexlify);
     }
     return 0;
 }
 
 static int _clear(PyObject *module)
 {
-    xxtea_mod_state *module_state = (xxtea_mod_state*)PyModule_GetState(module);
-    if (module_state) {
-        Py_CLEAR(module_state->binascii_hexlify);
-        Py_CLEAR(module_state->binascii_unhexlify);
+    xxtea_mod_state *state = (xxtea_mod_state*)PyModule_GetState(module);
+    if (state) {
+        Py_CLEAR(state->binascii_hexlify);
+        Py_CLEAR(state->binascii_unhexlify);
     }
     return 0;
 }
@@ -620,15 +794,15 @@ static void _free(void *module)
 }
 
 static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "xxtea",
-    NULL,
-    sizeof(struct xxtea_mod_state),
-    methods,
-    slots,
-    _traverse,
-    _clear,
-    _free
+    .m_base     = PyModuleDef_HEAD_INIT,
+    .m_name     = "xxtea",
+    .m_doc      = NULL,
+    .m_size     = sizeof(struct xxtea_mod_state),
+    .m_methods  = methods,
+    .m_slots    = slots,
+    .m_traverse = _traverse,
+    .m_clear    = _clear,
+    .m_free     = _free,
 };
 
 PyMODINIT_FUNC PyInit_xxtea(void)


### PR DESCRIPTION
Add a reusable XXTEA cipher type that holds key, rounds, and padding at construction time.  encrypt(data) and decrypt(data) take only data, using the stored settings — no per-call key/rounds/padding needed.

- xxtea.c: xxtea_Object struct with key, rounds, padding; METH_O methods
- tests/test.py: TestXXTEAType (16 tests) covering round-trip, random data, no-padding, rounds, error cases, and module-function equivalence
- tests/test_benchmarks.py: 8 new XXTEA type benchmarks
- README.rst: new XXTEA Type section and error examples