### PR TITLE
Remove Py_SET_SIZE polyfill for Python < 3.9

### DIFF
--- a/xxtea.c
+++ b/xxtea.c
@@ -31,12 +31,6 @@
 
 #define VERSION "5.0.0"
 
-#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
-static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
-{ ob->ob_size = size; }
-#define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)
-#endif
-
 #define DELTA 0x9e3779b9U
 #define MX (((z>>5^y<<2) + (y>>3^z<<4)) ^ ((sum^y) + (key[(p&3)^e] ^ z)))
 


### PR DESCRIPTION
The project requires Python >= 3.9, but xxtea.c carried a compatibility polyfill for Py_SET_SIZE targeting Python < 3.9. Py_SET_SIZE was added as a public API macro in Python 3.9, so this polyfill is dead code.