### PR TITLE
Release v5.3.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 CHANGELOG
 --------------
 
+v5.3.3 2026/08/14
+~~~~~~~~~~~~~~~~~~~
+
+- Assemble leftover data and PKCS#7 padding into complete words in
+  ``bytes2longs``, so ``encrypt()`` no longer needs to zero the output
+  buffer first.
+- Add Python 3.15 classifier.
+- Pin GitHub Actions to commit SHAs.
+
 v5.3.2 2026/07/24
 ~~~~~~~~~~~~~~~~~~~
 

--- a/xxtea.c
+++ b/xxtea.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#define VERSION "5.3.2"
+#define VERSION "5.3.3"
 
 #define DELTA 0x9e3779b9U
 #define MX (((z>>5^y<<2) + (y>>3^z<<4)) ^ ((sum^y) + (key[(p&3)^e] ^ z)))


### PR DESCRIPTION
Bump version to 5.3.3. `bytes2longs` now writes complete tail words so `encrypt()` no longer memsets the output buffer. Also adds the Python 3.15 classifier and pins GitHub Actions to commit SHAs.